### PR TITLE
Agregada condicion fiscal del cliente para servicio pyafipws

### DIFF
--- a/account_payment_group/models/account_payment.py
+++ b/account_payment_group/models/account_payment.py
@@ -308,7 +308,6 @@ class AccountPayment(models.Model):
         apply when the all the counterpart account are receivable/payable """
         # Si viene counterpart_aml entonces estamos viniendo de una
         # conciliacion desde el wizard
-        import pdb;pdb.set_trace()
         new_aml_dicts = self._context.get('new_aml_dicts', [])
         counterpart_aml_data = self._context.get('counterpart_aml_dicts', [])
         if counterpart_aml_data or new_aml_dicts:

--- a/account_payment_group/models/account_payment_group.py
+++ b/account_payment_group/models/account_payment_group.py
@@ -564,6 +564,8 @@ class AccountPaymentGroup(models.Model):
             if rec.partner_type:
                 rec.account_internal_type = MAP_PARTNER_TYPE_ACCOUNT_TYPE[
                     rec.partner_type]
+            else:
+                rec.account_internal_type = False
 
     def _compute_payment_difference(self):
         for rec in self:

--- a/l10n_ar_afipws_fe/models/move.py
+++ b/l10n_ar_afipws_fe/models/move.py
@@ -581,7 +581,7 @@ print "Observaciones:", wscdc.Obs
             moneda_ctz = inv.currency_id.rate
             if not moneda_id:
                 raise ValidationError('No esta definido el codigo AFIP en la moneda')
-
+            cond_iva_receptor = commercial_partner.l10n_ar_afip_responsibility_type_id.code
 
             CbteAsoc = inv.get_related_invoices_data()
 
@@ -595,7 +595,8 @@ print "Observaciones:", wscdc.Obs
                     imp_iva,
                     imp_trib, imp_op_ex, fecha_cbte, fecha_venc_pago,
                     fecha_serv_desde, fecha_serv_hasta,
-                    moneda_id, round(moneda_ctz,2)
+                    moneda_id, round(moneda_ctz,2),
+                    cond_iva_receptor
                 )
                 if inv.other_taxes_amount > 0:
                     for move_tax in inv.move_tax_ids:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ git+https://github.com/pysimplesoap/pysimplesoap@stable_py3k
 # fpdf>=1.7.2
 # dbf>=0.88.019
 # Pillow>=2.0.0
-git+https://github.com/reingart/pyafipws@py3k
+git+https://github.com/Serfe-com/pyafipws@py3k

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ git+https://github.com/pysimplesoap/pysimplesoap@stable_py3k
 # fpdf>=1.7.2
 # dbf>=0.88.019
 # Pillow>=2.0.0
-git+https://github.com/Serfe-com/pyafipws@py3k
+git+https://github.com/Serfe-com/pyafipws@ArreglarConditionIvaCliente


### PR DESCRIPTION
Permite agregar la condición de iva del cliente al emitir una factura por el servicio de ARCA/AFIP.

Este campo es requerido hace poco tiempo. Esto soluciona este problema.

Viene acompañado de https://github.com/reingart/pyafipws/pull/127